### PR TITLE
Fix parsing of the kubebuilder:resource tag

### DIFF
--- a/docgen.go
+++ b/docgen.go
@@ -434,6 +434,28 @@ func (d *Docgen) formatRawDoc(
 		switch {
 		case strings.HasPrefix(line, "TODO:"): // Ignore TODOs
 		case strings.HasPrefix(line, "todo:"): // Ignore TODOs
+		case strings.HasPrefix(line, "+example"):
+			annotations[exampleAnnotation] = strings.Split(line,"=")[1]
+		case strings.HasPrefix(line, "+groupName"):
+			annotations[groupNameAnnotation] = strings.Split(line,"=")[1]
+		case strings.HasPrefix(line, "+optional"):
+			annotations[line] = ""
+		case strings.HasPrefix(line, "+kubebuilder:default"):
+			annotations[defaultAnnotation] = strings.Split(line,"=")[1]
+		case strings.HasPrefix(line, "+kubebuilder:resource"):			
+			line = strings.TrimPrefix(line, "+kubebuilder:resource:")
+			if !strings.Contains(line, "=") {
+				annotations[line] = ""
+			} else if strings.HasPrefix(line, "scope") {
+				parts := strings.SplitN(line, ",", 2)
+				for _, arg := range parts {
+					values := strings.Split(arg, "=")
+					annotations[values[0]] = values[1]
+				}
+			} else {
+				values := strings.Split(line, "=")
+				annotations[values[0]] = values[1]
+			}
 		case strings.HasPrefix(line, "+"): // Code generator annotations
 			parts := strings.SplitN(line, "=", 2)
 			if len(parts) == 1 {

--- a/types.go
+++ b/types.go
@@ -84,7 +84,7 @@ const (
 	// Indicates root of a custom resource.
 	objectRootAnnotation = "kubebuilder:object:root"
 	// Scope of the API. Cluster or Namespace.
-	scopeAnnotation = "kubebuilder:resource:scope"
+	scopeAnnotation = "scope"
 	// Field defaults applied during API server admission.
 	defaultAnnotation = "kubebuilder:default"
 	// Custom example value for this documentation generator.


### PR DESCRIPTION
Parsing the kubebuilder:resource tag currenlty expects only one argument, scope. When the shortname argument is added the scope argument is no longer parsed correctly and cluster scoped examples are created as namespaced resources. This PR fixes this issue. 