### PR TITLE
Fix bools in examples

### DIFF
--- a/docgen.go
+++ b/docgen.go
@@ -548,7 +548,7 @@ func exampleFieldValue(
 	case "string":
 		return nextWord()
 	case "bool":
-		return "true"
+		return true
 	default:
 		if subObject, ok := subObjects[fieldType]; ok {
 			return exampleObject(subObject.Fields, subObjects)

--- a/template.md
+++ b/template.md
@@ -1,5 +1,5 @@
 {{define "typelink" -}}
-  {{$simpleTypes := list "string" "int" "int64" "uint64" "[]string" "[]int"}}
+  {{$simpleTypes := list "string" "int" "int64" "uint64" "[]string" "[]int" "bool"}}
   {{- if or (contains "." .) (has . $simpleTypes) -}}
     {{.}}
   {{- else -}}


### PR DESCRIPTION
This PR fixes invalid bool field value in yaml examples. It also removes the bool link that goes nowhere.